### PR TITLE
Fix json dump for array of objects

### DIFF
--- a/target_parquet/helpers.py
+++ b/target_parquet/helpers.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Union
 
 try:
@@ -53,7 +54,10 @@ def flatten(dictionary, flat_schema, parent_key="", sep="__"):
                 items.update(flatten(value, flat_schema, new_key, sep=sep))
             else:
                 if new_key in flat_schema:
-                    items[new_key] = str(value) if isinstance(value, list) else value
+                    if 'array' in flat_schema[new_key]:
+                        items[new_key] = json.dumps(value)
+                    else:
+                        items[new_key] = str(value) if isinstance(value, list) else value
     return items
 
 

--- a/target_parquet/helpers.py
+++ b/target_parquet/helpers.py
@@ -54,10 +54,7 @@ def flatten(dictionary, flat_schema, parent_key="", sep="__"):
                 items.update(flatten(value, flat_schema, new_key, sep=sep))
             else:
                 if new_key in flat_schema:
-                    if 'array' in flat_schema[new_key]:
-                        items[new_key] = json.dumps(value)
-                    else:
-                        items[new_key] = str(value) if isinstance(value, list) else value
+                    items[new_key] = json.dumps(value) if isinstance(value, list) else value
     return items
 
 

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -174,20 +174,23 @@ def test_flatten_schema_to_pyarrow_schema_type_not_defined():
 def test_flatten_array_fields():
     in_dict = {
         "int_array": [1, 2, 3],
-        "array_of_array": [1, 2, [3, 4]],
+        "array_of_int_array": [1, 2, [3, 4]],
+        "array_of_mixed_types": ["a", {"b":"value"}, ["c", "d"]],
         "string_array": ["a", "b", "c"],
         "object_array": [{"int": 1}, {"string1": "aaa'aaa"}, {"string2": 'aaa"aaa'}, {"array": [1, 2, 3]}, {'true': True}, {'false': False}, {'null': None}],
     }
     expected = {
         'int_array': '[1, 2, 3]',
-        'array_of_array': '[1, 2, [3, 4]]',
+        'array_of_int_array': '[1, 2, [3, 4]]',
+        "array_of_mixed_types": '["a", {"b": "value"}, ["c", "d"]]',
         'string_array': '["a", "b", "c"]',
         'object_array': '[{"int": 1}, {"string1": "aaa\'aaa"}, {"string2": "aaa\\"aaa"}, {"array": [1, 2, 3]}, {"true": true}, {"false": false}, {"null": null}]'
     }
 
     flat_schema = {
         "int_array": "array",
-        "array_of_array": "array",
+        "array_of_int_array": "array",
+        "array_of_mixed_types": "array",
         "string_array": ["null", "array"],
         "object_array": "array",
     }

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -169,3 +169,28 @@ def test_flatten_schema_to_pyarrow_schema_type_not_defined():
 
     with pytest.raises(NotImplementedError):
         flatten_schema_to_pyarrow_schema(in_dict, ["created_at"])
+
+
+def test_flatten_array_fields():
+    in_dict = {
+        "int_array": [1, 2, 3],
+        "array_of_array": [1, 2, [3, 4]],
+        "string_array": ["a", "b", "c"],
+        "object_array": [{"int": 1}, {"string1": "aaa'aaa"}, {"string2": 'aaa"aaa'}, {"array": [1, 2, 3]}, {'true': True}, {'false': False}, {'null': None}],
+    }
+    expected = {
+        'int_array': '[1, 2, 3]',
+        'array_of_array': '[1, 2, [3, 4]]',
+        'string_array': '["a", "b", "c"]',
+        'object_array': '[{"int": 1}, {"string1": "aaa\'aaa"}, {"string2": "aaa\\"aaa"}, {"array": [1, 2, 3]}, {"true": true}, {"false": false}, {"null": null}]'
+    }
+
+    flat_schema = {
+        "int_array": "array",
+        "array_of_array": "array",
+        "string_array": ["null", "array"],
+        "object_array": "array",
+    }
+    output = flatten(in_dict, flat_schema)
+    print(output)
+    assert output == expected

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -15,7 +15,7 @@ def test_flatten():
         "key_1": 1,
         "key_2__key_3": 2,
         "key_2__key_4__key_5": 3,
-        "key_2__key_4__key_6": "['10', '11']",
+        "key_2__key_4__key_6": '["10", "11"]',
     }
 
     flat_schema = {


### PR DESCRIPTION
When an array of objects was being directly forced to string in the pyarrow schema cast, it was converting the python object to string without considering that this is a json string (that can be converted in the future).
To fix that, a step was added to convert the entire array to a json format before the final cast.