### PR TITLE
Fix json states with Decimal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "target-parquet"
-version = "1.0.1"
+version = "1.0.2"
 description = "`target-parquet` is a Singer target for parquet, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Joao Amaral <joao.amaral@automattic.com>"]

--- a/target_parquet/target.py
+++ b/target_parquet/target.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from decimal import Decimal
 
 from singer_sdk import typing as th
 from singer_sdk.target_base import Target
@@ -11,6 +12,13 @@ from singer_sdk.target_base import Target
 from target_parquet.sinks import (
     ParquetSink,
 )
+
+
+class DecimalEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Decimal):
+            return float(obj)
+        return super().default(obj)
 
 
 class TargetParquet(Target):
@@ -68,11 +76,8 @@ class TargetParquet(Target):
 
     def _write_state_message(self, state: dict) -> None:
         """Emit the stream's latest state.
-
-        Args:
-            state: TODO
         """
-        state_json = json.dumps(state, use_decimal=True)
+        state_json = json.dumps(state, cls=DecimalEncoder)
         self.logger.info("Emitting completed target state %s", state_json)
         sys.stdout.write(f"{state_json}\n")
         sys.stdout.flush()

--- a/target_parquet/target.py
+++ b/target_parquet/target.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+import sys
+
 from singer_sdk import typing as th
 from singer_sdk.target_base import Target
 
@@ -61,6 +64,18 @@ class TargetParquet(Target):
     ).to_dict()
 
     default_sink_class = ParquetSink
+
+
+    def _write_state_message(self, state: dict) -> None:
+        """Emit the stream's latest state.
+
+        Args:
+            state: TODO
+        """
+        state_json = json.dumps(state, use_decimal=True)
+        self.logger.info("Emitting completed target state %s", state_json)
+        sys.stdout.write(f"{state_json}\n")
+        sys.stdout.flush()
 
 
 if __name__ == "__main__":

--- a/target_parquet/target.py
+++ b/target_parquet/target.py
@@ -15,6 +15,7 @@ from target_parquet.sinks import (
 
 
 class DecimalEncoder(json.JSONEncoder):
+    """JSON encoder for Decimal used in state."""
     def default(self, obj):
         if isinstance(obj, Decimal):
             return float(obj)
@@ -75,8 +76,7 @@ class TargetParquet(Target):
 
 
     def _write_state_message(self, state: dict) -> None:
-        """Emit the stream's latest state.
-        """
+        """Emit the stream's latest state."""
         state_json = json.dumps(state, cls=DecimalEncoder)
         self.logger.info("Emitting completed target state %s", state_json)
         sys.stdout.write(f"{state_json}\n")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import typing as t
+from decimal import Decimal
 from pathlib import Path
 from uuid import uuid4
 
 import pytest
 from singer_sdk.testing import get_target_test_class
 
-from target_parquet.target import TargetParquet
+from target_parquet.target import TargetParquet, DecimalEncoder
 
 TEST_OUTPUT_DIR = Path(f".output/test_{uuid4()}/")
 SAMPLE_CONFIG: dict[str, t.Any] = {
@@ -45,3 +47,37 @@ class TestTargetParquet(StandardTargetTests):  # type: ignore[misc, valid-type]
         test_output_dir.mkdir(parents=True, exist_ok=True)
         yield test_output_dir
         shutil.rmtree(test_output_dir)
+
+
+def test_decimal_encoding():
+    # States could have decimal values, so we need to ensure they are encoded as floats
+    data = {
+        "value1": Decimal("10.5"),
+        "value2": Decimal("3.14159"),
+        "value3": 42,
+        "nested": {"value4": Decimal("2.71828")},
+        "list_of_values": [Decimal("1.1"), Decimal("2.2"), 3],
+    }
+
+    encoded_json = json.dumps(data, cls=DecimalEncoder)
+    expected_json = json.dumps({
+        "value1": 10.5,
+        "value2": 3.14159,
+        "value3": 42,
+        "nested": {"value4": 2.71828},
+        "list_of_values": [1.1, 2.2, 3],
+    })
+    assert encoded_json == expected_json
+
+def test_non_decimal_types():
+    # Test that non-decimal types are not affected by the DecimalEncoder
+    data = {
+        "value1": 10.5,
+        "value2": 42,
+        "nested": {"value4": "string_value"},
+        "list_of_values": [1.1, 2.2, 3],
+    }
+
+    encoded_json = json.dumps(data, cls=DecimalEncoder)
+    expected_json = json.dumps(data)
+    assert encoded_json == expected_json

--- a/tests/utils/test_parquet.py
+++ b/tests/utils/test_parquet.py
@@ -172,5 +172,3 @@ def test_get_pyarrow_table_size(sample_data, sample_schema):
     # Check if the result is a non-negative float
     assert isinstance(size_in_mb, float)
     assert pytest.approx(size_in_mb, 0.1) == 7.15
-
-

--- a/tests/utils/test_parquet.py
+++ b/tests/utils/test_parquet.py
@@ -172,3 +172,5 @@ def test_get_pyarrow_table_size(sample_data, sample_schema):
     # Check if the result is a non-negative float
     assert isinstance(size_in_mb, float)
     assert pytest.approx(size_in_mb, 0.1) == 7.15
+
+


### PR DESCRIPTION
In some cases, the state contains a Decimal, and it fails with ` TypeError: Object of type Decimal is not JSON serializable`. So, this PR includes a decoder to convert the Decimal to a float.