### PR TITLE
fix: Using correct compression_method config value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "target-parquet"
-version = "1.1.0"
+version = "1.1.1"
 description = "`target-parquet` is a Singer target for parquet, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Joao Amaral <joao.amaral@automattic.com>"]

--- a/target_parquet/sinks.py
+++ b/target_parquet/sinks.py
@@ -134,7 +134,7 @@ class ParquetSink(BatchSink):
             write_parquet_file(
                 self.pyarrow_df,
                 self.destination_path,
-                compression_method=self.config.get("compression", "gzip"),
+                compression_method=self.config.get("compression_method", "gzip"),
                 basename_template=self.basename_template,
                 partition_cols=self.partition_cols,
             )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -481,3 +481,42 @@ def test_e2e_partition_cols_validation(
             input=StringIO(example1_schema_messages["messages"]),
             finalize=True,
         )
+def test_e2e_create_file_compression_method_default(
+        monkeypatch, test_output_dir, sample_config, example1_schema_messages
+):
+    """Test that the target creates a file with the expected records"""
+    monkeypatch.setattr("time.time", lambda: 1700000000)
+
+    target_sync_test(
+        TargetParquet(config=sample_config),
+        input=StringIO(example1_schema_messages["messages"]),
+        finalize=True,
+    )
+
+    assert (
+            len(os.listdir(test_output_dir / example1_schema_messages["stream_name"])) == 1
+    )
+
+    files = os.listdir(test_output_dir / example1_schema_messages["stream_name"])
+    assert files[0].endswith('.gz.parquet')
+
+
+def test_e2e_create_file_compression_method_snappy(
+        monkeypatch, test_output_dir, sample_config, example1_schema_messages
+):
+    """Test that the target creates a file with the expected records"""
+    monkeypatch.setattr("time.time", lambda: 1700000000)
+
+    target_sync_test(
+        TargetParquet(
+            config=sample_config | {"compression_method": "snappy"}),
+        input=StringIO(example1_schema_messages["messages"]),
+        finalize=True,
+    )
+
+    assert (
+            len(os.listdir(test_output_dir / example1_schema_messages["stream_name"])) == 1
+    )
+
+    files = os.listdir(test_output_dir / example1_schema_messages["stream_name"])
+    assert files[0].endswith('.snappy.parquet')


### PR DESCRIPTION
During some tests, I found that there was a mismatch between the `compression_method` configuration from the docs and the key being used in the code.

This fixes the config retrieval by using the expected key and adds a couple of tests for compression method.